### PR TITLE
removing async await logics on the model/ctrl/drivers builds to allow…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockbase",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "blockbase MVC node framework project",
   "main": "src/app.js",
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ const config = require('config')
  * @param {Object} options - setup options { root : __dirname }
  * @param {function} callback - main callback transporting the app variable
  */
-module.exports = async (options, callback) => {
+module.exports = (options, callback) => {
     let app = {
         root : options.root || __dirname,
         config
@@ -28,12 +28,12 @@ module.exports = async (options, callback) => {
     app.models = require('./models')(app)
     app.controllers = require('./controllers')(app)
 
-    await app.drivers.build(`${__dirname}/drivers`)
-    await app.models.build(`${__dirname}/models`)
+    app.drivers.build(`${__dirname}/drivers`)
+    app.models.build(`${__dirname}/models`)
 
-    await app.drivers.build()
-    await app.models.build()
-    await app.controllers.build()
+    app.drivers.build()
+    app.models.build()
+    app.controllers.build()
 
     app.drivers.logger.success('App', `${app.config.name} is alive !`)
     

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -15,11 +15,10 @@ module.exports = (app, path = `${app.root}/controllers/`) => {
      * index the controllers
      * @private
      * @param {string} file - file to index
-     * @param {number} index - position of the file in its parent folder
      *
      * @returns {Object} update controllers namespace
      */
-    function index(file, index) {
+    function index(file) {
         if(!file.includes('.js') && !!fs.readdirSync(path + file).length){
             let files = fs.readdirSync(path + file)
             if((typeof files ==='undefined' || files.length <= 0) && app.controllers[file].init)
@@ -27,7 +26,8 @@ module.exports = (app, path = `${app.root}/controllers/`) => {
 
             if(!app.controllers[file]) app.controllers[file] = {}
 
-            files.forEach((f, i) => {
+            for(let i = 0; i < files.length; i++){
+                let f = files[i]
                 const sub = f.replace('.js', '')
                 app.controllers[file][sub] = require(`${path}${file}/${sub}`)(app)
 
@@ -35,7 +35,7 @@ module.exports = (app, path = `${app.root}/controllers/`) => {
                     app.drivers.logger.log('Controllers', `Initializing >> app.controllers.${file}.${sub}.*`)
                     app.controllers[file][sub].init()
                 }
-            })
+            }
         } else {
             file = file.replace('.js', '')
             app.controllers[file] = require(path + file)(app)
@@ -55,10 +55,12 @@ module.exports = (app, path = `${app.root}/controllers/`) => {
          *
          * @returns {Object} update controllers namespace
          */
-        async build() {
+        build() {
             if(fs.existsSync(path)){
                 let files = fs.readdirSync(path).filter(junk.not)
-                files.forEach(index)
+                for(let i = 0; i < files.length; i++){
+                    index(files[i])
+                }
             }
 
             return app.controllers

--- a/src/drivers.js
+++ b/src/drivers.js
@@ -27,19 +27,19 @@ module.exports = (app) => {
                     return mod.includes('blockbase-')
                 })
 
-                drivers.forEach((driver, idx) => {
-                    if(!app.drivers[driver.replace('blockbase-', '')])
-                        app.drivers[driver.replace('blockbase-', '')] = require(driver)(app)
-                })
+                for(let i = 0; i < drivers.length; i++){
+                    if(!app.drivers[drivers[i].replace('blockbase-', '')])
+                        app.drivers[drivers[i].replace('blockbase-', '')] = require(drivers[i])(app)                    
+                }
             }
 
             if(fs.existsSync(path)){
                 let files = fs.readdirSync(path).filter(junk.not)
 
-                files.forEach((f, i) => {
-                    if(f.includes('.js'))
-                        app.drivers[f.replace('.js', '')] = require(`${path}/${f.replace('.js', '')}`)(app)
-                })
+                for(let i = 0; i < files.length; i++){
+                    if(files[i].includes('.js'))
+                        app.drivers[files[i].replace('.js', '')] = require(`${path}/${files[i].replace('.js', '')}`)(app)
+                }
             }
 
             return app.drivers

--- a/src/models.js
+++ b/src/models.js
@@ -22,10 +22,10 @@ module.exports = (app) => {
             if(fs.existsSync(path)){
                 let files = fs.readdirSync(path)
 
-                files.forEach((f, i) => {
-                    if(f.includes('.js'))
-                        app.models[f.replace('.js', '')] = require(`${path}/${f.replace('.js', '')}`)(app)
-                })
+                for(let i=0; i<files.length; i++){
+                    if(files[i].includes('.js'))
+                        app.models[files[i].replace('.js', '')] = require(`${path}/${files[i].replace('.js', '')}`)(app)
+                }
             }
 
             return app.models


### PR DESCRIPTION
In order to prepare the framework to be used on server-less (like AWS Lambda) we should allow the global export of the app on `app.js`

I've done an update to remove so any async/await logic on the controllers / drivers / models builds logics. 